### PR TITLE
Set up SQL Express with database migration

### DIFF
--- a/src/ContractingPlatform.Api/ConfigureServices.cs
+++ b/src/ContractingPlatform.Api/ConfigureServices.cs
@@ -4,12 +4,13 @@
 using ContractingPlatform.Core;
 using ContractingPlatform.Infrastructure;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Configuration;
 
 namespace Microsoft.Extensions.DependencyInjection;
 
 public static class ConfigureServices
 {
-    public static void AddApiServices(this IServiceCollection services)
+    public static void AddApiServices(this IServiceCollection services, IConfiguration configuration)
     {
         services.AddCors(options => options.AddPolicy("CorsPolicy",
             builder => builder
@@ -23,7 +24,7 @@ public static class ConfigureServices
         services.AddSwaggerGen();
 
         services.AddDbContext<ContractingPlatformContext>(options =>
-            options.UseInMemoryDatabase("ContractingPlatformDb"));
+            options.UseSqlServer(configuration.GetConnectionString("DefaultConnection")));
 
         services.AddScoped<IContractingPlatformContext>(provider =>
             provider.GetRequiredService<ContractingPlatformContext>());

--- a/src/ContractingPlatform.Api/Program.cs
+++ b/src/ContractingPlatform.Api/Program.cs
@@ -5,7 +5,7 @@ using ContractingPlatform.Infrastructure;
 
 var builder = WebApplication.CreateBuilder(args);
 
-builder.Services.AddApiServices();
+builder.Services.AddApiServices(builder.Configuration);
 
 var app = builder.Build();
 

--- a/src/ContractingPlatform.Api/appsettings.json
+++ b/src/ContractingPlatform.Api/appsettings.json
@@ -1,4 +1,7 @@
 {
+  "ConnectionStrings": {
+    "DefaultConnection": "Server=.\\SQLEXPRESS;Database=ContractingPlatformDb;Trusted_Connection=True;TrustServerCertificate=True;MultipleActiveResultSets=true"
+  },
   "Logging": {
     "LogLevel": {
       "Default": "Information",

--- a/src/ContractingPlatform.Infrastructure/ContractingPlatform.Infrastructure.csproj
+++ b/src/ContractingPlatform.Infrastructure/ContractingPlatform.Infrastructure.csproj
@@ -9,6 +9,11 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="9.0.0" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="9.0.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="9.0.0">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="9.0.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\ContractingPlatform.Core\ContractingPlatform.Core.csproj" />

--- a/src/ContractingPlatform.Infrastructure/DesignTimeDbContextFactory.cs
+++ b/src/ContractingPlatform.Infrastructure/DesignTimeDbContextFactory.cs
@@ -1,0 +1,24 @@
+// Copyright (c) Quinntyne Brown. All Rights Reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Design;
+using Microsoft.Extensions.Configuration;
+
+namespace ContractingPlatform.Infrastructure;
+
+public class DesignTimeDbContextFactory : IDesignTimeDbContextFactory<ContractingPlatformContext>
+{
+    public ContractingPlatformContext CreateDbContext(string[] args)
+    {
+        var configuration = new ConfigurationBuilder()
+            .SetBasePath(Path.Combine(Directory.GetCurrentDirectory(), "../ContractingPlatform.Api"))
+            .AddJsonFile("appsettings.json", optional: false)
+            .Build();
+
+        var optionsBuilder = new DbContextOptionsBuilder<ContractingPlatformContext>();
+        optionsBuilder.UseSqlServer(configuration.GetConnectionString("DefaultConnection"));
+
+        return new ContractingPlatformContext(optionsBuilder.Options);
+    }
+}


### PR DESCRIPTION
…upport

- Add SQL Express connection string to appsettings.json
- Update ConfigureServices to use SQL Server instead of InMemory database
- Add EF Core Design and Configuration.Json packages for migrations
- Add DesignTimeDbContextFactory for CLI migration support
- Update Program.cs to pass configuration to service registration